### PR TITLE
Token Authentication

### DIFF
--- a/back-end/sports_platform/sports_platform/settings.py
+++ b/back-end/sports_platform/sports_platform/settings.py
@@ -38,8 +38,18 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'sports_platform_api.apps.SportsPlatformApiConfig'
+    'sports_platform_api.apps.SportsPlatformApiConfig',
+    'rest_framework.authtoken',
 ]
+
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES':(
+        'rest_framework.authentication.TokenAuthentication',
+    )
+}
+
+AUTH_USER_MODEL = 'sports_platform_api.User'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/back-end/sports_platform/sports_platform_api/tests/tests_login.py
+++ b/back-end/sports_platform/sports_platform_api/tests/tests_login.py
@@ -1,12 +1,21 @@
 from django.test import Client, TestCase
 from ..models import User
+from rest_framework.authtoken.models import Token
+from django.contrib.auth import authenticate
+
 
 class LoginTest(TestCase):
 
     def setUp(self):
         self.client = Client()
 
-        User.objects.create_user(identifier="lion", password="roarroar", email="lion@roar.com")
+        self.lion_user = User.objects.create_user(identifier="lion", password="roarroar", email="lion@roar.com")
+        self.cat_user = User.objects.create_user(identifier="cat", password="meowmeow", email="cat@meow.com")
+
+        self.lion_token, _ = Token.objects.get_or_create(user=self.lion_user)
+        self.cat_token, _ = Token.objects.get_or_create(user=self.cat_user)
+
+        authenticate(identifier=self.cat_user.identifier, password=self.cat_user.password)
 
         self.request_bodies = {'no_identifier':{'password':'qwerttyty'},
         'no_password':{'identifier':'asds'},
@@ -16,7 +25,8 @@ class LoginTest(TestCase):
         'identifier_starts_with_dot':{'identifier':'.asds', 'password':'qwerttyty'},
         'short_password_identifier_with_special':{'identifier':'as-ds', 'password':'qwe'},
         'success': {'identifier':'lion', 'password':'roarroar'},
-        'wrong_credentials': {'identifier':'notlion', 'password':'roarroar'}
+        'wrong_credentials': {'identifier':'notlion', 'password':'roarroar'},
+        'already_logged_in': {'identifier': 'cat', 'password': 'meowmeow'},
         }
 
         self.response_bodies = {'no_identifier':{"message": {"identifier": ["This field is required."]}},
@@ -27,6 +37,8 @@ class LoginTest(TestCase):
         'identifier_starts_with_dot':{"message": {"identifier": ["Only English characters, numbers and . are allowed. Cannot start or end with ."]}},
         'short_password_identifier_with_special':{"message": {"identifier": ["Only English characters, numbers and . are allowed. Cannot start or end with ."], "password": ["Ensure this field has at least 8 characters."]}},
         'wrong_credentials':{"message": "Check credentials."},
+        'success': {"token": self.lion_token.key},
+        'already_logged_in': {"message": "Already logged in."},
         }
 
         self.path = '/users/login'
@@ -85,8 +97,9 @@ class LoginTest(TestCase):
         test_type = 'success'
         request_body = self.request_bodies[test_type]
         response = self.client.post(self.path, request_body)
-        print(response)
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertTrue(self.lion_user.is_authenticated)
 
     def test_wrong_credentials(self):
         test_type = 'wrong_credentials'
@@ -94,3 +107,11 @@ class LoginTest(TestCase):
         response = self.client.post(self.path, request_body)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_already_logged_in(self):
+        test_type = 'already_logged_in'
+        request_body = self.request_bodies[test_type]
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertEqual(response.status_code, 400)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -4,17 +4,17 @@ from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from ..validation import user_validation
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth import logout
 from ..models import User
 from ..controllers import Guest
 import re
-
+from rest_framework.authtoken.models import Token
+import django.contrib.auth 
 
 @api_view(['POST'])
 def login(request):
 
     if request.user.is_authenticated:
-        return Response(data= {"message": "Already logged in, logout first."}, status=400)
+        return Response(data= {"message": "Already logged in."}, status=400)
 
     validation = user_validation.Login(data = request.data)
     if not validation.is_valid():
@@ -26,10 +26,9 @@ def login(request):
     try:
         user = guest.login()
         if user is not None:
-            return Response(status=200)
+            token, _ = Token.objects.get_or_create(user=user)
+            return Response(data={"token": token.key},status=200)
         else:
             return Response(data={"message": "Check credentials."}, status=403)
     except Exception as e:
         return Response(data={"message": "Try later."}, status=500)
-
-    


### PR DESCRIPTION
Token authentication will be used.
`users/login` return a token for the user.
For other request that require user to be logged in should include this in its headers.  

From [documentation](https://www.django-rest-framework.org/api-guide/authentication/#tokenauthentication):
> For clients to authenticate, the token key should be included in the Authorization HTTP header. The key should be prefixed by the string literal "Token", with whitespace separating the two strings. For example: ```Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b```

To verify the authentication `request.user.is_authenticated` can be used.

