### PR TITLE
Reset password users/recover

### DIFF
--- a/back-end/sports_platform/sports_platform/settings.py
+++ b/back-end/sports_platform/sports_platform/settings.py
@@ -142,8 +142,8 @@ STATIC_URL = '/static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = os.getenv("EMAIL_HOST")
-EMAIL_PORT = os.getenv("EMAIL_PORT")
+EMAIL_HOST = os.environ.get("EMAIL_HOST")
+EMAIL_PORT = os.environ.get("EMAIL_PORT")
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
-EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")

--- a/back-end/sports_platform/sports_platform/settings.py
+++ b/back-end/sports_platform/sports_platform/settings.py
@@ -140,3 +140,10 @@ STATIC_URL = '/static/'
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_PORT = os.getenv("EMAIL_PORT")
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")

--- a/back-end/sports_platform/sports_platform_api/controllers/guest.py
+++ b/back-end/sports_platform/sports_platform_api/controllers/guest.py
@@ -1,5 +1,7 @@
 from django.contrib.auth import authenticate
 from ..models.user_models import User
+import string
+import random
 
 class Guest:
 
@@ -26,3 +28,16 @@ class Guest:
             except Exception as e:
                 raise e
         return user
+
+def generate_random_password():
+
+    characters = list(string.ascii_letters + string.digits + ".*")
+    random.shuffle(characters)
+
+    password = []
+    for i in range(15):
+        password.append(random.choice(characters))
+
+    random.shuffle(password)
+
+    return "".join(password)

--- a/back-end/sports_platform/sports_platform_api/controllers/guest.py
+++ b/back-end/sports_platform/sports_platform_api/controllers/guest.py
@@ -73,5 +73,4 @@ def generate_random_password():
         password.append(random.choice(characters))
 
     random.shuffle(password)
-
     return "".join(password)

--- a/back-end/sports_platform/sports_platform_api/tests/test_recover.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_recover.py
@@ -5,7 +5,7 @@ from django.contrib.auth import authenticate
 from .test_helper_functions import create_mock_user
 from django.core import mail
 
-class LoginTest(TestCase):
+class RecoverTest(TestCase):
 
     def setUp(self):
         self.client = Client()

--- a/back-end/sports_platform/sports_platform_api/tests/test_recover.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_recover.py
@@ -1,0 +1,92 @@
+from django.test import Client, TestCase
+from ..models import User
+from rest_framework.authtoken.models import Token
+from django.contrib.auth import authenticate
+from .test_helper_functions import create_mock_user
+from django.core import mail
+
+class LoginTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+        lion_info = {'identifier': 'lion',
+                     'password': 'roarroar', 'email': 'lion@roar.com'}
+        cat_info = {'identifier': 'cat',
+                    'password': 'meowmeow', 'email': 'cat@meow.com'}
+
+        self.lion_user = create_mock_user(lion_info)
+        self.cat_user = create_mock_user(cat_info)
+
+        self.lion_token, _ = Token.objects.get_or_create(user=self.lion_user)
+        self.cat_token, _ = Token.objects.get_or_create(user=self.cat_user)
+
+        authenticate(identifier=self.cat_user.identifier,
+                     password=self.cat_user.password)
+
+        self.request_bodies = {'wrong_email': {'email': 'lion3@roar.com'},
+                               'no_email': {},
+                               'success': {'email': 'lion@roar.com'},
+                               'already_logged_in': {'email': 'cat@meow.com'},
+                               }
+
+        self.response_bodies = {'wrong_email': {"message": "If email provided is correct, a reset password is sent, please check spam."},
+                                'no_email': {"message": {"email": ["This field is required."]}},
+                                'success': {"message": "If email provided is correct, a reset password is sent, please check spam."},
+                                'already_logged_in': {"message": "Already logged in use change password on settings instead."},
+                                }
+
+        self.path = '/users/recover'
+
+    def test_wrong_email(self):
+        test_type = 'wrong_email'
+        request_body = self.request_bodies[test_type]
+        response = self.client.post(self.path, request_body)
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_no_email(self):
+        test_type = 'no_email'
+        request_body = self.request_bodies[test_type]
+        response = self.client.post(self.path, request_body)
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_already_logged_in(self):
+        test_type = 'already_logged_in'
+        request_body = self.request_bodies[test_type]
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+
+        self.assertEqual(len(mail.outbox), 0)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+    
+    def test_success(self):
+        test_type = 'success'
+        request_body = self.request_bodies[test_type]
+        response = self.client.post(self.path, request_body)
+
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject,
+                         'New Password for your Squad Game Account')
+        self.assertIn(
+            f"new password for the account with username {self.lion_user.identifier} is", mail.outbox[0].body)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+        authenticed = authenticate(identifier=self.lion_user.identifier,
+                     password=self.lion_user.password)
+
+        self.assertIsNone(authenticed)
+
+        new_pass = mail.outbox[0].body.split(",")[0][-15:]
+
+        authenticed_new = authenticate(identifier=self.lion_user.identifier,
+                                       password=new_pass)
+
+        self.assertEqual(authenticed_new.user_id, self.lion_user.user_id)

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -4,5 +4,6 @@ from .views import *
 urlpatterns = [
     path('users', user_views.create_user),
     path('users/login', user_views.login),
-    path('users/logout', user_views.logout)
+    path('users/logout', user_views.logout),
+    path('users/recover', user_views.forgot_password)
 ]

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -5,6 +5,6 @@ urlpatterns = [
     path('users', user_views.create_user),
     path('users/login', user_views.login),
     path('users/logout', user_views.logout),
-    path('users/recover', user_views.forgot_password)
+    path('users/recover', user_views.forgot_password),
     path('users/<int:user_id>', user_views.get_user)
 ]

--- a/back-end/sports_platform/sports_platform_api/validation/user_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/user_validation.py
@@ -24,3 +24,7 @@ class Login(serializers.Serializer):
 
 class Block(serializers.Serializer):
     date = serializers.DateField(validators = [date])
+
+
+class Recover(serializers.Serializer):
+    email = serializers.EmailField(required=True)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -69,3 +69,38 @@ def logout(request):
 
     return Response({"message": "Successfully logged out."},
                     status=200)
+
+
+@api_view(['POST'])
+def forgot_password(request):
+
+    if request.user.is_authenticated:
+        return Response({"message": "Already logged in use change password on settings instead."},
+                        status=401)
+
+    validation = user_validation.Recover(data=request.data)
+    
+    if not validation.is_valid():
+        return Response(data={"message": validation.errors}, status=400)
+
+    try:
+        validated_data = validation.validated_data
+        guest = Guest(None, None)
+
+        res = guest.forget_password(validated_data['email'])
+
+        if res == 100:
+            # No user with email
+            return Response({"message": "If email provided is correct, a reset password is sent, please check spam."},
+                            status=200)
+        elif res == 500:
+            return Response({"message": "Try again."},
+                            status=500)
+
+    except Exception as e:
+        print(e)
+        return Response({"message": "Try again."},
+                        status=500)
+
+    return Response({"message": "If email provided is correct, a reset password is sent, please check spam."},
+                    status=200)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -119,7 +119,6 @@ def forgot_password(request):
                             status=500)
 
     except Exception as e:
-        print(e)
         return Response({"message": "Try again."},
                         status=500)
 


### PR DESCRIPTION
Reset password endpoint is created. Closing #166 

When a user provides a email, if email exists in the database, an email with contents is sent:
```
Your new password for the account with username {user identifier} is {new password}, you can login using this password and change it on settings.
```

Subject of the email is `New Password for your Squad Game Account`

For security, user should be able to set the new password and the password should not be exposed, this improvement is opened as an issue and will be fixed later: #228