### PR TITLE
Follow Related Endpoints

### DIFF
--- a/back-end/sports_platform/sports_platform_api/models/__init__.py
+++ b/back-end/sports_platform/sports_platform_api/models/__init__.py
@@ -4,5 +4,5 @@ https://docs.djangoproject.com/en/3.2/topics/db/models/#organizing-models-in-a-p
 Import other models on this file
 """
 
-from .user_models import User, SportSkillLevel
+from .user_models import User, SportSkillLevel, Follow
 from .sport_models import Sport

--- a/back-end/sports_platform/sports_platform_api/models/user_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/user_models.py
@@ -102,6 +102,15 @@ class User(AbstractBaseUser):
             print(e)
             return 500
 
+    def unfollow(self, user_id):
+        try:
+            num_deleted, _ = Follow.objects.filter(follower = self.user_id, following = user_id).delete()
+            if num_deleted == 0:
+                return 403
+        except Exception as e:
+            print(e)
+            return 500
+
 
 class SportSkillLevel(models.Model):
     class Meta:

--- a/back-end/sports_platform/sports_platform_api/models/user_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/user_models.py
@@ -90,12 +90,14 @@ class User(AbstractBaseUser):
     def follow(self, user_id):
         date = datetime.datetime.now()
         try:
-            Follow.objects.create(follower = self.id, following = user_id, date = date)
+            to_follow = User.objects.get(user_id=user_id)
+            Follow.objects.create(follower = self, following = to_follow, date = date)
             return True
-        except IntegrityError as e:
+        except User.DoesNotExist:
             return 400
         except Exception as e:
-            return 403
+            print(e)
+            return 500
 
 
 class SportSkillLevel(models.Model):

--- a/back-end/sports_platform/sports_platform_api/models/user_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/user_models.py
@@ -155,6 +155,42 @@ class User(AbstractBaseUser):
             print(e)
             return 500
 
+    def get_follower(self):
+        try:
+            follower = self.follower.all()
+
+            data_dict = dict()
+            data_dict['@context'] = "https://www.w3.org/ns/activitystreams"
+            data_dict['summary'] = f"{self.identifier}'s being followed activities."
+            data_dict['type'] = "Collection"
+            data_dict['total_items'] = len(follower)
+            data_dict['items'] = []
+
+            for follower_user in follower:
+                one_follow = dict()
+                one_follow['@context'] = "https://www.w3.org/ns/activitystreams"
+                one_follow['summary'] = f"{follower_user.follower.identifier} followed {self.identifier}"
+                one_follow['type'] = "Follow"
+
+                one_follow['actor'] = {
+                    "type": "https://schema.org/Person",
+                    "@id":  follower_user.follower.user_id,
+                    "identifier": follower_user.follower.identifier
+                }
+
+                one_follow['object'] = {
+                    "type": "https://schema.org/Person",
+                    "@id":  self.user_id,
+                    "identifier": self.identifier
+                }
+
+                data_dict['items'].append(one_follow)
+
+            return data_dict
+        except Exception as e:
+            return 500
+
+
 
 class SportSkillLevel(models.Model):
     class Meta:

--- a/back-end/sports_platform/sports_platform_api/models/user_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/user_models.py
@@ -63,6 +63,7 @@ class UserManager(BaseUserManager):
 class Follow(models.Model):
     class Meta:
         db_table = 'follow'
+        unique_together = (('follower', 'following'),)
 
     follower = models.ForeignKey('User', related_name='following', on_delete=models.CASCADE)
     following = models.ForeignKey('User', related_name='follower', on_delete=models.CASCADE)
@@ -94,7 +95,9 @@ class User(AbstractBaseUser):
             Follow.objects.create(follower = self, following = to_follow, date = date)
             return True
         except User.DoesNotExist:
-            return 400
+            return 401
+        except IntegrityError as e:
+            return 402
         except Exception as e:
             print(e)
             return 500

--- a/back-end/sports_platform/sports_platform_api/models/user_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/user_models.py
@@ -99,7 +99,6 @@ class User(AbstractBaseUser):
         except IntegrityError as e:
             return 402
         except Exception as e:
-            print(e)
             return 500
 
     def unfollow(self, user_id):
@@ -108,7 +107,6 @@ class User(AbstractBaseUser):
             if num_deleted == 0:
                 return 403
         except Exception as e:
-            print(e)
             return 500
 
     def add_sport_interest(self, sport_name, skill_level):
@@ -162,7 +160,6 @@ class User(AbstractBaseUser):
 
             return data_dict
         except Exception as e:
-            print(e)
             return 500
 
     def get_follower(self):

--- a/back-end/sports_platform/sports_platform_api/models/user_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/user_models.py
@@ -119,6 +119,42 @@ class User(AbstractBaseUser):
         return [{"@type":"PropertyValue","name": skill.sport_id, "value":skill.skill_level} for skill in skills]
 
 
+    def get_following(self):
+        try:
+            following = self.following.all()
+
+            data_dict = dict()
+            data_dict['@context'] = "https://www.w3.org/ns/activitystreams"
+            data_dict['summary'] = f"{self.identifier}'s following activities."
+            data_dict['type'] = "Collection"
+            data_dict['total_items'] = len(following)
+            data_dict['items'] = []
+
+            for following_user in following:
+                one_follow = dict()
+                one_follow['@context'] = "https://www.w3.org/ns/activitystreams"
+                one_follow['summary'] = f"{self.identifier} followed {following_user.following.identifier}"
+                one_follow['type'] = "Follow"
+
+                one_follow['actor'] = {
+                    "type": "https://schema.org/Person",
+                    "@id":  self.user_id,
+                    "identifier": self.identifier
+                }
+
+                one_follow['object'] = {
+                    "type": "https://schema.org/Person",
+                    "@id":  following_user.following.user_id,
+                    "identifier": following_user.following.identifier
+                }
+
+                data_dict['items'].append(one_follow)
+
+            return data_dict
+        except Exception as e:
+            print(e)
+            return 500
+
 
 class SportSkillLevel(models.Model):
     class Meta:

--- a/back-end/sports_platform/sports_platform_api/tests/test_follow.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_follow.py
@@ -146,7 +146,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.post(
@@ -162,7 +162,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.post(
@@ -179,7 +179,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.post(
@@ -194,7 +194,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.post(
@@ -209,7 +209,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.post(
@@ -224,7 +224,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.delete(
@@ -240,7 +240,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.delete(
@@ -255,7 +255,7 @@ class FollowTest(TestCase):
         request_user_id = self.request_user_id[test_type]
         token = self.request_token[test_type]
 
-        path = "/users/" + str(request_param) + "/follower"
+        path = "/users/" + str(request_param) + "/following"
 
         request_body = {"user_id": request_user_id}
         response = self.client.delete(

--- a/back-end/sports_platform/sports_platform_api/tests/test_follow.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_follow.py
@@ -1,0 +1,291 @@
+from django.test import Client, TestCase
+from ..models import Follow
+from rest_framework.authtoken.models import Token
+from django.contrib.auth import authenticate
+from .test_helper_functions import create_mock_user
+
+
+class FollowTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        self.maxDiff = None
+
+        lion_info = {'identifier': 'lion',
+                     'password': 'roarroar', 'email': 'lion@roar.com'}
+        cat_info = {'identifier': 'cat',
+                    'password': 'meowmeow', 'email': 'cat@meow.com'}
+        dog_info = {'identifier': 'dog',
+                    'password': 'barkbark', 'email': 'dog@bark.com'}
+
+        self.lion_user = create_mock_user(lion_info)
+        self.cat_user = create_mock_user(cat_info)
+        self.dog_user = create_mock_user(dog_info)
+
+        self.lion_token, _ = Token.objects.get_or_create(user=self.lion_user)
+        self.cat_token, _ = Token.objects.get_or_create(user=self.cat_user)
+        self.dog_token, _ = Token.objects.get_or_create(user=self.dog_user)
+
+        authenticate(identifier=self.lion_user.identifier,
+                     password=self.lion_user.password)
+        authenticate(identifier=self.cat_user.identifier,
+                     password=self.cat_user.password)
+        authenticate(identifier=self.dog_user.identifier,
+                     password=self.dog_user.password)
+
+        Follow.objects.create(follower=self.lion_user, following=self.cat_user)
+        Follow.objects.create(follower=self.lion_user, following=self.dog_user)
+
+        self.request_param = {'follow_success': self.cat_user.user_id,
+                              'follow_for_other': self.dog_user.user_id,
+                              'get_follower': self.cat_user.user_id,
+                              'already_followed': self.lion_user.user_id,
+                              'follow_yourself': self.cat_user.user_id,
+                              'follow_non_existing': self.cat_user.user_id,
+                              'get_following': self.lion_user.user_id,
+                              'unfollow_success': self.lion_user.user_id,
+                              'unfollow_for_other': self.lion_user.user_id,
+                              'unfollow_non_following': self.cat_user.user_id,
+                              }
+
+        self.request_user_id = {'follow_success': self.dog_user.user_id,
+                                'follow_for_other': self.lion_user.user_id,
+                                'already_followed': self.dog_user.user_id,
+                                'follow_yourself': self.cat_user.user_id,
+                                'follow_non_existing': 576,
+                                'get_following': self.cat_user.user_id,
+                                'unfollow_success': self.cat_user.user_id,
+                                'unfollow_for_other': self.dog_user.user_id,
+                                'unfollow_non_following': self.dog_user.user_id,
+                                }
+
+        self.request_token = {'follow_success': self.cat_token,
+                              'follow_for_other': self.cat_token,
+                              'get_follower': self.lion_token,
+                              'already_followed': self.lion_token,
+                              'follow_yourself': self.cat_token,
+                              'follow_non_existing': self.cat_token,
+                              'get_following': self.cat_token,
+                              'unfollow_success': self.lion_token,
+                              'unfollow_for_other': self.cat_token,
+                              'unfollow_non_following': self.cat_token,
+                              }
+
+        self.response_bodies = {'follow_for_other': {"message": "Not allowed to follow for another user."},
+                                'get_following': {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "summary": "lion's following activities.",
+            "type": "Collection",
+            "total_items": 2,
+            "items": [
+                {
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "summary": "lion followed cat",
+                    "type": "Follow",
+                    "actor": {
+                        "type": "https://schema.org/Person",
+                        "@id": self.lion_user.user_id,
+                        "identifier": self.lion_user.identifier
+                    },
+                    "object": {
+                        "type": "https://schema.org/Person",
+                        "@id": self.cat_user.user_id,
+                        "identifier": self.cat_user.identifier
+                    }
+                },
+                {
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "summary": "lion followed dog",
+                    "type": "Follow",
+                    "actor": {
+                        "type": "https://schema.org/Person",
+                        "@id": self.lion_user.user_id,
+                        "identifier": self.lion_user.identifier
+                    },
+                    "object": {
+                        "type": "https://schema.org/Person",
+                        "@id": self.dog_user.user_id,
+                        "identifier": self.dog_user.identifier
+                    }
+                },
+            ]
+        },
+            'get_follower': {
+            "@context": "https://www.w3.org/ns/activitystreams",
+            "summary": "cat's being followed activities.",
+            "type": "Collection",
+            "total_items": 1,
+            "items": [
+                {
+                    "@context": "https://www.w3.org/ns/activitystreams",
+                    "summary": "lion followed cat",
+                    "type": "Follow",
+                    "actor": {
+                        "type": "https://schema.org/Person",
+                        "@id": self.lion_user.user_id,
+                        "identifier": self.lion_user.identifier
+                    },
+                    "object": {
+                        "type": "https://schema.org/Person",
+                        "@id": self.cat_user.user_id,
+                        "identifier": self.cat_user.identifier
+                    }
+                }
+            ]
+        },
+            'already_followed': {"message": "User already followed."},
+            'follow_yourself': {"message": "User cannot follow itself."},
+            'follow_non_existing': {"message": "Enter a valid user_id to follow."},
+            'unfollow_for_other': {"message": "Not allowed to unfollow for another user."},
+            'unfollow_non_following': {"message": "Enter a valid user_id to unfollow."},
+        }
+
+    def test_follow_success(self):
+        test_type = 'follow_success'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.post(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(Follow.objects.filter(
+            follower=request_param, following=request_user_id).exists())
+
+    def test_follow_for_other(self):
+        test_type = 'follow_for_other'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.post(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertFalse(Follow.objects.filter(
+            follower=request_param, following=request_user_id).exists())
+
+    def test_already_followed(self):
+        test_type = 'already_followed'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.post(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_follow_yourself(self):
+        test_type = 'follow_yourself'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.post(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_follow_non_existing(self):
+        test_type = 'follow_non_existing'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.post(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_unfollow_success(self):
+        test_type = 'unfollow_success'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.delete(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(Follow.objects.filter(
+            follower=request_param, following=request_user_id).exists())
+
+    def test_unfollow_for_other(self):
+        test_type = 'unfollow_for_other'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.delete(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_unfollow_non_following(self):
+        test_type = 'unfollow_non_following'
+        request_param = self.request_param[test_type]
+        request_user_id = self.request_user_id[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        request_body = {"user_id": request_user_id}
+        response = self.client.delete(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_get_follower(self):
+        test_type = 'get_follower'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/follower"
+
+        response = self.client.get(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_get_following(self):
+        test_type = 'get_following'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/users/" + str(request_param) + "/following"
+
+        response = self.client.get(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, self.response_bodies[test_type])

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -4,6 +4,8 @@ from .views import *
 urlpatterns = [
     path('users/login', user_views.login),
     path('users/<int:user_id>/follow', user_views.follow_user),
+    path('users/<int:user_id>/following', user_views.get_following),
+    path('users/<int:user_id>/follower', user_views.get_follower),
     path('users/<int:user_id>/unfollow', user_views.unfollow_user),
     path('users', user_views.create_user),
     path('users/<int:user_id>', user_views.get_user),

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -3,8 +3,8 @@ from .views import *
 
 urlpatterns = [
     path('users/login', user_views.login),
-    path('users/<int:user_id>/follower', user_views.follow_user),
-    path('users/<int:user_id>/following', user_views.get_following),
+    path('users/<int:user_id>/following', user_views.follow_user),
+    path('users/<int:user_id>/follower', user_views.get_follower),
     path('users', user_views.create_user),
     path('users/<int:user_id>', user_views.get_user),
     path('users/logout', user_views.logout)

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from .views import *
 
 urlpatterns = [
-    path('users/login', user_views.login)
+    path('users/login', user_views.login),
+    path('users/<int:user_id>/follow', user_views.follow_user),
 ]

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -4,4 +4,5 @@ from .views import *
 urlpatterns = [
     path('users/login', user_views.login),
     path('users/<int:user_id>/follow', user_views.follow_user),
+    path('users/<int:user_id>/unfollow', user_views.unfollow_user),
 ]

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -3,10 +3,8 @@ from .views import *
 
 urlpatterns = [
     path('users/login', user_views.login),
-    path('users/<int:user_id>/follow', user_views.follow_user),
+    path('users/<int:user_id>/follower', user_views.follow_user),
     path('users/<int:user_id>/following', user_views.get_following),
-    path('users/<int:user_id>/follower', user_views.get_follower),
-    path('users/<int:user_id>/unfollow', user_views.unfollow_user),
     path('users', user_views.create_user),
     path('users/<int:user_id>', user_views.get_user),
     path('users/logout', user_views.logout)

--- a/back-end/sports_platform/sports_platform_api/validation/user_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/user_validation.py
@@ -23,3 +23,6 @@ class Login(serializers.Serializer):
 
 class Block(serializers.Serializer):
     date = serializers.DateField(validators = [date])
+
+class Follow(serializers.Serializer):
+    user_id = serializers.IntegerField(min_value = 1, max_value = 9223372036854775807)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -91,22 +91,22 @@ def follow_user(request, user_id):
     user_to_follow = validation.validated_data['user_id']
 
     if user_to_follow == current_user.user_id:
-        return Response(data={"message": "User cannot follow itself."}, status=400)  
+        return Response(data={"message": "User cannot follow itself."}, status=400)
 
     try:
         res = current_user.follow(user_to_follow)
 
         if res == 401:
-            return Response(data={"message": "Enter a valid user_id to follow."}, status=400)  
+            return Response(data={"message": "Enter a valid user_id to follow."}, status=400)
         elif res == 402:
-            return Response(data={"message": "User already followed."}, status=400)  
+            return Response(data={"message": "User already followed."}, status=400)
         elif res == 500:
             return Response(data={"message": "Try later."}, status=500)
         else:
-            return Response(status=200) 
+            return Response(status=200)
 
     except Exception as e:
-        return Response(data=str(e), status=500) 
+        return Response(data=str(e), status=500)
 
 
 @api_view(['POST'])
@@ -123,21 +123,21 @@ def unfollow_user(request, user_id):
     validation = user_validation.Follow(data=request.data)
     if not validation.is_valid():
         return Response(validation.errors, status=400)
-    
-    user_to_follow = validation.validated_data['user_id']
+
+    user_to_unfollow = validation.validated_data['user_id']
 
     try:
-        res = current_user.unfollow(user_to_follow)
+        res = current_user.unfollow(user_to_unfollow)
 
         if res == 403:
-            return Response(data={"message": "Enter a valid user_id to unfollow."}, status=400)  
+            return Response(data={"message": "Enter a valid user_id to unfollow."}, status=400)
         elif res == 500:
             return Response(data={"message": "Try later."}, status=500)
         else:
-            return Response(status=200) 
+            return Response(status=200)
 
     except Exception as e:
-        return Response(data=str(e), status=500)  
+        return Response(data=str(e), status=500)
 @api_view(['GET'])
 def get_following(request, user_id):
 

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -164,21 +164,23 @@ def follow_user(request, user_id):
             return Response(data={"message": "Login required."}, status=403)
 
         try:
-            user_followed = User.objects.get(user_id=user_id)
+            user_following = User.objects.get(user_id=user_id)
 
-            follower = user_followed.get_follower()
+            following = user_following.get_following()
 
-            if follower == 500:
+            if following == 500:
                 return Response(data={"message": "Try later."}, status=500)
             else:
-                return Response(data=follower, status=200)
+                return Response(data=following, status=200)
         except User.DoesNotExist:
             return Response(data={"message": "User does not exist."}, status=400)
         except Exception as e:
             return Response(data={"message": "Try later."}, status=500)
 
+        
+
 @api_view(['GET'])
-def get_following(request, user_id):
+def get_follower(request, user_id):
 
     current_user = request.user
 
@@ -186,15 +188,16 @@ def get_following(request, user_id):
         return Response(data={"message": "Login required."}, status=403)
 
     try:
-        user_following = User.objects.get(user_id=user_id)
+        user_followed = User.objects.get(user_id=user_id)
 
-        following = user_following.get_following()
+        follower = user_followed.get_follower()
 
-        if following == 500:
+        if follower == 500:
             return Response(data={"message": "Try later."}, status=500)
         else:
-            return Response(data = following, status=200)
+            return Response(data=follower, status=200)
     except User.DoesNotExist:
         return Response(data={"message": "User does not exist."}, status=400)
     except Exception as e:
         return Response(data={"message": "Try later."}, status=500)
+    

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -146,14 +146,7 @@ def get_following(request, user_id):
     if not current_user.is_authenticated:
         return Response(data={"message": "Login required."}, status=403)
 
-def logout(request):
-    
-    if not request.user.is_authenticated:
-        return Response({"message": "User not logged in."},
-                        status=401)
     try:
-        request.user.auth_token.delete()
-        django.contrib.auth.logout(request)
         user_following = User.objects.get(user_id=user_id)
 
         following = user_following.get_following()
@@ -165,12 +158,8 @@ def logout(request):
     except User.DoesNotExist:
         return Response(data={"message": "User does not exist."}, status=400)
     except Exception as e:
-        return Response({"message": "Try again."},
-                        status=500)
         return Response(data={"message": "Try later."}, status=500)
 
-    return Response({"message": "Successfully logged out."},
-                    status=200)
 
 @api_view(['GET'])
 def get_follower(request, user_id):

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -138,6 +138,13 @@ def unfollow_user(request, user_id):
 
     except Exception as e:
         return Response(data=str(e), status=500)  
+@api_view(['GET'])
+def get_following(request, user_id):
+
+    current_user = request.user
+
+    if not current_user.is_authenticated:
+        return Response(data={"message": "Login required."}, status=403)
 
 def logout(request):
     
@@ -147,10 +154,20 @@ def logout(request):
     try:
         request.user.auth_token.delete()
         django.contrib.auth.logout(request)
+        user_following = User.objects.get(user_id=user_id)
 
+        following = user_following.get_following()
+
+        if following == 500:
+            return Response(data={"message": "Try later."}, status=500)
+        else:
+            return Response(data = following, status=200)
+    except User.DoesNotExist:
+        return Response(data={"message": "User does not exist."}, status=400)
     except Exception as e:
         return Response({"message": "Try again."},
                         status=500)
+        return Response(data={"message": "Try later."}, status=500)
 
     return Response({"message": "Successfully logged out."},
                     status=200)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -73,6 +73,24 @@ def login(request):
     except Exception as e:
         return Response(data={"message": "Try later."}, status=500)
 
+
+@api_view(['POST'])
+def logout(request):
+
+    if not request.user.is_authenticated:
+        return Response({"message": "User not logged in."},
+                        status=401)
+    try:
+        request.user.auth_token.delete()
+        django.contrib.auth.logout(request)
+
+    except Exception as e:
+        return Response({"message": "Try again."},
+                        status=500)
+
+    return Response({"message": "Successfully logged out."},
+                    status=200)
+
 @api_view(['POST'])
 def follow_user(request, user_id):
 
@@ -138,6 +156,7 @@ def unfollow_user(request, user_id):
 
     except Exception as e:
         return Response(data=str(e), status=500)
+
 @api_view(['GET'])
 def get_following(request, user_id):
 

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -132,7 +132,7 @@ def follow_user(request, user_id):
         current_user = request.user
 
         if not current_user.is_authenticated:
-            return Response(data={"message": "Login required."}, status=403)
+            return Response(data={"message": "Login required."}, status=401)
         
         if current_user.user_id != user_id:
             return Response(data={"message": "Not allowed to follow for another user."}, status=403)
@@ -165,7 +165,7 @@ def follow_user(request, user_id):
         current_user = request.user
 
         if not current_user.is_authenticated:
-            return Response(data={"message": "Login required."}, status=403)
+            return Response(data={"message": "Login required."}, status=401)
 
         if current_user.user_id != user_id:
             return Response(data={"message": "Not allowed to unfollow for another user."}, status=403)
@@ -187,14 +187,14 @@ def follow_user(request, user_id):
                 return Response(status=200)
 
         except Exception as e:
-            return Response(data=str(e), status=500)
+            return Response(data={"message": "Try later."}, status=500)
 
     elif request.method == 'GET':
 
         current_user = request.user
 
         if not current_user.is_authenticated:
-            return Response(data={"message": "Login required."}, status=403)
+            return Response(data={"message": "Login required."}, status=401)
 
         try:
             user_following = User.objects.get(user_id=user_id)
@@ -218,7 +218,7 @@ def get_follower(request, user_id):
     current_user = request.user
 
     if not current_user.is_authenticated:
-        return Response(data={"message": "Login required."}, status=403)
+        return Response(data={"message": "Login required."}, status=401)
 
     try:
         user_followed = User.objects.get(user_id=user_id)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -172,3 +172,24 @@ def logout(request):
     return Response({"message": "Successfully logged out."},
                     status=200)
 
+@api_view(['GET'])
+def get_follower(request, user_id):
+
+    current_user = request.user
+
+    if not current_user.is_authenticated:
+        return Response(data={"message": "Login required."}, status=403)
+
+    try:
+        user_followed = User.objects.get(user_id=user_id)
+
+        follower = user_followed.get_follower()
+
+        if follower == 500:
+            return Response(data={"message": "Try later."}, status=500)
+        else:
+            return Response(data=follower, status=200)
+    except User.DoesNotExist:
+        return Response(data={"message": "User does not exist."}, status=400)
+    except Exception as e:
+        return Response(data={"message": "Try later."}, status=500)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -37,8 +37,6 @@ def follow_user(request, user_id):
     if not current_user.is_authenticated:
         return Response(data={"message": "Login required."}, status=403)
     
-    print(current_user)
-
     if current_user.user_id != user_id:
         return Response(data={"message": "Not allowed to follow for another user."}, status=403)
 
@@ -58,6 +56,37 @@ def follow_user(request, user_id):
             return Response(data={"message": "Enter a valid user_id to follow."}, status=400)  
         elif res == 402:
             return Response(data={"message": "User already followed."}, status=400)  
+        elif res == 500:
+            return Response(data={"message": "Try later."}, status=500)
+        else:
+            return Response(status=200) 
+
+    except Exception as e:
+        return Response(data=str(e), status=500) 
+
+
+@api_view(['POST'])
+def unfollow_user(request, user_id):
+
+    current_user = request.user
+
+    if not current_user.is_authenticated:
+        return Response(data={"message": "Login required."}, status=403)
+    
+    if current_user.user_id != user_id:
+        return Response(data={"message": "Not allowed to unfollow for another user."}, status=403)
+
+    validation = user_validation.Follow(data=request.data)
+    if not validation.is_valid():
+        return Response(validation.errors, status=400)
+    
+    user_to_follow = validation.validated_data['user_id']
+
+    try:
+        res = current_user.unfollow(user_to_follow)
+
+        if res == 403:
+            return Response(data={"message": "Enter a valid user_id to unfollow."}, status=400)  
         elif res == 500:
             return Response(data={"message": "Try later."}, status=500)
         else:


### PR DESCRIPTION
Endpoints for follow, unfollow, get followers, get following users are created. 

Get followers and ger following return the response in jsonld format with activity streams of following events.
Example for get following:  
```
{
    "@context": "https://www.w3.org/ns/activitystreams",
    "summary": "esb18's following activities.",
    "type": "Collection",
    "total_items": 1,
    "items": [
        {
            "@context": "https://www.w3.org/ns/activitystreams",
            "summary": "esb18 followed esb",
            "type": "Follow",
            "actor": {
                "type": "https://schema.org/Person",
                "@id": 10,
                "identifier": "esb18"
            },
            "object": {
                "type": "https://schema.org/Person",
                "@id": 3,
                "identifier": "esb"
            }
        }
    ]
}
```

Related issues, closing #163 #168 #169 #170 #171