### PR TITLE
Backend create event

### DIFF
--- a/back-end/sports_platform/sports_platform_api/helpers/__init__.py
+++ b/back-end/sports_platform/sports_platform_api/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .geo import *

--- a/back-end/sports_platform/sports_platform_api/helpers/geo.py
+++ b/back-end/sports_platform/sports_platform_api/helpers/geo.py
@@ -1,0 +1,18 @@
+import requests
+
+def get_address(latitude, longitude):
+
+    URI = f'https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat={str(latitude)}&lon={str(longitude)}'
+
+    try:
+        headers = {"Accept-Language": "en-US,en;q=0.5"}
+        res = requests.get(URI, headers=headers)
+
+        if res.status_code != 200:
+            return 500
+        if not "address" in res.json().keys():
+            return 400
+        return res.json()['address']
+        
+    except:
+        return 500

--- a/back-end/sports_platform/sports_platform_api/models/__init__.py
+++ b/back-end/sports_platform/sports_platform_api/models/__init__.py
@@ -6,3 +6,4 @@ Import other models on this file
 
 from .user_models import User, SportSkillLevel, Follow, Block
 from .sport_models import Sport
+from .event_models import *

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -30,7 +30,33 @@ class Event(models.Model):
     maxSkillLevel = models.IntegerField()
 
     created_on = models.DateTimeField()
-    
+
+    def create_event(data):
+
+        data['created_on'] = datetime.datetime.now()
+        address = get_address(data['latitude'], data['longitude'])
+
+        if address == 500:
+            return 500
+        elif address == 400:
+            return 101
+
+        data['country'] = address['country']
+        data['city'] = address['state']
+        data['district'] = address['county']
+
+        try:
+            data['sport'] = Sport.objects.get(name=data['sport'])
+        except Sport.DoesNotExist:
+            return 102
+        try:
+            with transaction.atomic():
+                event = Event.objects.create(**data)
+            return {"@id": event.event_id}
+        except Exception as e:
+            return 500
+
+
 
 
 class EventParticipants(models.Model):

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -1,12 +1,16 @@
 from django.db import models
-
+import datetime
+from requests.api import get
+from ..helpers import get_address
+from django.db import IntegrityError, transaction
+from ..models import Sport
 
 class Event(models.Model):
     class Meta:
         db_table = 'event'
 
     event_id = models.BigAutoField(primary_key=True)
-    name = models.CharField(primary_key=True, max_length=100, primary_key=True)
+    name = models.CharField(max_length=100)
     sport = models.ForeignKey('Sport', on_delete=models.CASCADE)
     organizer = models.ForeignKey('User', on_delete=models.CASCADE)
     description = models.TextField(blank=True)
@@ -15,10 +19,11 @@ class Event(models.Model):
 
     latitude = models.DecimalField(max_digits=9, decimal_places=6)
     longitude = models.DecimalField(max_digits=9, decimal_places=6)
-    city = models.CharField()
-    district = models.CharField()
+    city = models.CharField(max_length=200)
+    district = models.CharField(max_length=200)
+    country = models.CharField(max_length=200)
 
-    minimumAttendeeCapacity = models.IntegerField(min_value=0)
+    minimumAttendeeCapacity = models.IntegerField()
     maximumAttendeeCapacity = models.IntegerField()
     maxSpectatorCapacity = models.IntegerField()
     minSkillLevel = models.IntegerField()

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -4,6 +4,7 @@ from requests.api import get
 from ..helpers import get_address
 from django.db import IntegrityError, transaction
 from ..models import Sport
+from datetime import datetime, timezone
 
 class Event(models.Model):
     class Meta:
@@ -33,7 +34,10 @@ class Event(models.Model):
 
     def create_event(data):
 
-        data['created_on'] = datetime.datetime.now()
+        utc_dt = datetime.now(timezone.utc)  # UTC time
+        dt = utc_dt.astimezone()
+
+        data['created_on'] = dt
         address = get_address(data['latitude'], data['longitude'])
 
         if address == 500:

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -32,6 +32,7 @@ class Event(models.Model):
 
     created_on = models.DateTimeField()
 
+    @staticmethod
     def create_event(data):
 
         utc_dt = datetime.now(timezone.utc)  # UTC time

--- a/back-end/sports_platform/sports_platform_api/tests/test_create_event.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_create_event.py
@@ -1,0 +1,107 @@
+from django.test import Client, TestCase
+from ..models import User
+from rest_framework.authtoken.models import Token
+from django.contrib.auth import authenticate
+from .test_helper_functions import create_mock_user
+from ..models import Event, Sport
+
+class CreateEventTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+        cat_info = {'identifier': 'cat',
+                    'password': 'meowmeow', 'email': 'cat@meow.com'}
+
+        self.cat_user = create_mock_user(cat_info)
+
+        self.cat_token, _ = Token.objects.get_or_create(user=self.cat_user)
+
+        authenticate(identifier=self.cat_user.identifier,
+                     password=self.cat_user.password)
+
+        Sport.objects.create(name="soccer")
+
+        self.request_body = {
+                                    "name": "lets play soccer",
+                                    "sport": "soccer",
+                                    "startDate": "2021-12-13T13:00:00",
+                                    "latitude": 41.002697,
+                                    "longitude": 39.716763,
+                                    "minimumAttendeeCapacity": 5,
+                                    "maximumAttendeeCapacity": 50,
+                                    "maxSpectatorCapacity": 59,
+                                    "minSkillLevel": 3,
+                                    "maxSkillLevel": 5
+                                }
+
+
+        self.response_bodies = {'no_name': {"message": {"name": ["This field is required."]}},
+                                'wrong_sport': {"message": "Enter a valid sport."},
+                                'wrong_coordinate': {"message": {"latitude": ["Ensure this value is less than or equal to 90."],"longitude": ["Ensure this value is greater than or equal to -180."]}},
+                                
+                                'bigger_min_skill': {"message": {"skillLevel": ["minSkillLevel should be smaller than or equal to maxSkillLevel"]}},
+                                'wrong_date': {"message": {"startDate": [
+                                    "Datetime has wrong format. Use one of these formats instead: YYYY-MM-DDThh:mm[:ss[.uuuuuu]][+HH:MM|-HH:MM|Z]."
+                                ]}}
+                                }
+
+        self.path = '/events'
+        self.maxDiff=None
+
+
+    def test_no_name(self):
+        test_type = 'no_name'
+        request_body = self.request_body
+        del request_body['name']
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertEqual(response.status_code, 400)
+
+    def test_wrong_sport(self):
+        test_type = 'wrong_sport'
+        request_body = self.request_body
+        request_body['sport'] = "non-existing_sport"
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertEqual(response.status_code, 400)
+
+    def test_wrong_coordinate(self):
+        test_type = 'wrong_coordinate'
+        request_body = self.request_body
+        request_body['latitude'] = 91
+        request_body['longitude'] = -191
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertEqual(response.status_code, 400)
+
+    def test_bigger_min_skill(self):
+        test_type = 'bigger_min_skill'
+        request_body = self.request_body
+        request_body['minSkillLevel'] = 5
+        request_body['maxSkillLevel'] = 3
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertEqual(response.status_code, 400)
+
+    def test_wrong_date(self):
+        test_type = 'wrong_date'
+        request_body = self.request_body
+        request_body['startDate'] = "June 13"
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertEqual(response.status_code, 400)
+
+    def test_success(self):
+        request_body = self.request_body
+        response = self.client.post(
+            self.path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {self.cat_token.key}'})
+
+        self.assertEqual(response.data['@context'], "https://schema.org/SportsEvent")
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Event.objects.get(event_id = response.data['@id']).name, request_body['name'])

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
 
-from sports_platform_api.views import sport_views
 from .views import *
 
 urlpatterns = [
@@ -13,5 +12,7 @@ urlpatterns = [
     path('users/logout', user_views.logout),
     path('users/recover', user_views.forgot_password),
     path('users/<int:user_id>/blocked', user_views.block_user),
-    path('users/<user_id>/visible_attributes',user_views.set_visibility)
+    path('users/<user_id>/visible_attributes', user_views.set_visibility),
+
+    path('events', event_views.create_event),
 ]

--- a/back-end/sports_platform/sports_platform_api/validation/event_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/event_validation.py
@@ -20,9 +20,9 @@ class Event(serializers.Serializer):
     def validate(self, data):
 
         if data['minSkillLevel'] > data['maxSkillLevel']:
-            raise serializers.ValidationError("minSkillLevel should be smaller than or equal to maxSkillLevel")
+            raise serializers.ValidationError({"skillLevel": "minSkillLevel should be smaller than or equal to maxSkillLevel"})
 
         if not data['startDate'].time():
-            raise serializers.ValidationError("startDate should include time")
+            raise serializers.ValidationError({"time": "startDate should include time"})
 
         return data

--- a/back-end/sports_platform/sports_platform_api/validation/event_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/event_validation.py
@@ -4,25 +4,25 @@ class Event(serializers.Serializer):
 
     name = serializers.CharField(min_length=2, max_length=100, required=True)
     sport = serializers.CharField(required=True)
-    description = models.CharField(required=False)
+    description = serializers.CharField(required=False)
 
-    startDate = models.DateTimeField(format='iso-8601', required=True)
+    startDate = serializers.DateTimeField(format='iso-8601', required=True)
 
-    latitude = models.DecimalField(max_digits=9, decimal_places=6, required=True)
-    longitude = models.DecimalField(max_digits=9, decimal_places=6, required=True)
+    latitude = serializers.DecimalField(max_digits=9, decimal_places=6, max_value=90, min_value=-90, required=True)
+    longitude = serializers.DecimalField(max_digits=9, decimal_places=6, max_value=180, min_value=-180, required=True)
 
-    minimumAttendeeCapacity = models.IntegerField(min_value=0, required=True)
-    maximumAttendeeCapacity = models.IntegerField(min_value=1, required=True)
-    maxSpectatorCapacity = models.IntegerField(min_value=0, required=True)
-    minSkillLevel = models.IntegerField(min_value=1, max_value=5, required=True)
-    maxSkillLevel = models.IntegerField(min_value=1, max_value=5, required=True)
+    minimumAttendeeCapacity = serializers.IntegerField(min_value=0, required=True)
+    maximumAttendeeCapacity = serializers.IntegerField(min_value=1, required=True)
+    maxSpectatorCapacity = serializers.IntegerField(min_value=0, required=True)
+    minSkillLevel = serializers.IntegerField(min_value=1, max_value=5, required=True)
+    maxSkillLevel = serializers.IntegerField(min_value=1, max_value=5, required=True)
 
     def validate(self, data):
 
-        if data['minSkillSevel'] > data['maxSkillSevel']:
+        if data['minSkillLevel'] > data['maxSkillLevel']:
             raise serializers.ValidationError("minSkillLevel should be smaller than or equal to maxSkillLevel")
 
-        if not (data['startDate'].contains('T') or data['startDate'].contains('t')):
+        if not data['startDate'].time():
             raise serializers.ValidationError("startDate should include time")
 
         return data

--- a/back-end/sports_platform/sports_platform_api/views/__init__.py
+++ b/back-end/sports_platform/sports_platform_api/views/__init__.py
@@ -4,3 +4,5 @@ Check https://simpleisbetterthancomplex.com/tutorial/2016/08/02/how-to-split-vie
 and adding to urls.py
 """
 from .user_views import *
+from .sport_views import *
+from .event_views import *

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -1,0 +1,43 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from ..models import Event
+from ..validation import event_validation
+
+
+
+@api_view(['POST'])
+def create_event(request):
+
+    if not request.user.is_authenticated:
+        return Response({"message": "User not logged in."},
+                        status=401)
+
+    organizer = request.user
+
+    validation = event_validation.Event(data=request.data)
+
+    if not validation.is_valid():
+        return Response(data={"message": validation.errors}, status=400)
+
+    validated_body = validation.validated_data
+    validated_body['organizer'] = organizer
+
+
+    try:
+        res = Event.create_event(validated_body)
+        
+        if res == 101:
+            return Response(data={"message": 'Check coordinates.'}, status=400)
+        elif res == 102:
+            return Response(data={"message": 'Enter a valid sport.'}, status=400)
+        elif res == 500:
+            return Response(data={"message": 'Try Later.'}, status=500)
+
+        response = dict()
+        response['@context'] = 'https://schema.org/SportsEvent'
+        response['@id'] = res['@id']
+
+        return Response(data=response, status=201)
+        
+    except Exception:
+        return Response(data={"message": 'There is an internal error, try again later.'}, status=500)


### PR DESCRIPTION
Endpoint to create event is created. 
Inputs required with example:
```
{
    "name": "lets play football2",
    "sport": "soccer",
    "startDate": "2021-12-13T13:00:00",
    "latitude": 141.002697,
    "longitude": 239.716763,
    "minimumAttendeeCapacity": 5,
    "maximumAttendeeCapacity":50,
    "maxSpectatorCapacity":59,
    "minSkillLevel":1,
    "maxSkillLevel":3
}
```
Start date format is iso8601.
Also a description can be added with string type.
Unittests are implemented.
Closing #257 