### PR TITLE
Backend Event Participation

### DIFF
--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -102,8 +102,8 @@ class EventParticipants(models.Model):
         db_table = 'event_participants'
         unique_together = (('user', 'event'),)
 
-    user = models.ForeignKey('User', on_delete=models.CASCADE)
-    event = models.ForeignKey('Event', on_delete=models.CASCADE)
+    user = models.ForeignKey('User', related_name='participating_events', on_delete=models.CASCADE)
+    event = models.ForeignKey('Event', related_name='participant_users', on_delete=models.CASCADE)
     accepted_on = models.DateTimeField()
 
 
@@ -112,9 +112,9 @@ class EventSpectators(models.Model):
         db_table = 'event_spectators'
         unique_together = (('user', 'event'),)
 
-    user = models.ForeignKey('User', on_delete=models.CASCADE)
-    event = models.ForeignKey('Event', on_delete=models.CASCADE)
-    joined_on = models.DateTimeField()
+    user = models.ForeignKey('User', related_name='spectating_events', on_delete=models.CASCADE)
+    event = models.ForeignKey('Event', related_name='spectator_users',  on_delete=models.CASCADE)
+    requested_on = models.DateTimeField()
 
 
 class EventParticipationRequesters(models.Model):
@@ -122,6 +122,6 @@ class EventParticipationRequesters(models.Model):
         db_table = 'event_participation_requesters'
         unique_together = (('user', 'event'),)
 
-    user = models.ForeignKey('User', on_delete=models.CASCADE)
-    event = models.ForeignKey('Event', on_delete=models.CASCADE)
+    user = models.ForeignKey('User', related_name='interested_events', on_delete=models.CASCADE)
+    event = models.ForeignKey('Event', related_name='interested_users', on_delete=models.CASCADE)
     requested_on = models.DateTimeField()

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -207,11 +207,25 @@ class Event(models.Model):
         dt = utc_dt.astimezone()
 
         try:
-            num_of_spectators = len(self.interested_users.all())
+            num_of_spectators = len(self.spectator_users.all())
             if num_of_spectators >= self.maxSpectatorCapacity:
-                return 403 # Full Capacity
+                return 403  # Full Capacity
             requester = User.objects.get(user_id=user_id)
-            EventSpectators.objects.create(event=self, user=requester, requested_on=dt)
+
+            try:
+                EventParticipants.objects.get(event=self, user=requester)
+                return 404  # already patricipating
+            except EventParticipants.DoesNotExist:
+                pass
+
+            try:
+                EventParticipationRequesters.objects.get(event=self, user=requester)
+                return 405  # already patricipating
+            except EventParticipants.DoesNotExist:
+                pass
+
+            EventSpectators.objects.create(
+                event=self, user=requester, requested_on=dt)
             return True
         except User.DoesNotExist:  # User does not exist
             return 401

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -157,6 +157,27 @@ class Event(models.Model):
         except Exception as e:
             return 500
 
+    def get_spectators(self):
+
+        try:
+            spectators = self.spectator_users.all()
+        except Exception as e:
+            return 500
+
+        spectator_users = []
+
+        for spectator in spectators:
+
+            data_dict = dict()
+
+            data_dict['@context'] = "https://schema.org/Person"
+            data_dict['@id'] = spectator.user.user_id
+            data_dict['identifier'] = spectator.user.identifier
+
+            spectator_users.append(data_dict)
+
+        return spectator_users
+
 
 class EventParticipants(models.Model):
     class Meta:

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -162,6 +162,17 @@ class Event(models.Model):
 
         data_dict['total_items'] = len(data_dict['items'])
         return data_dict
+    def delete_interest(self, user):
+
+        try:
+            request_object = EventParticipationRequesters.objects.get(event=self, user=user)
+            request_object.delete()
+            return True
+        except EventParticipationRequesters.DoesNotExist:
+            return 401
+        except Exception as e:
+            return 500
+
     def delete_spectator(self, user):
 
         try:

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -202,6 +202,19 @@ class Event(models.Model):
             return 401
         except Exception as e:
             return 500
+
+    def delete_participant(self, user):
+
+        try:
+            request_object = EventParticipants.objects.get(event=self, user=user)
+            request_object.delete()
+            return True
+        except EventParticipants.DoesNotExist:
+            return 401
+        except Exception as e:
+            return 500
+
+
     def add_spectator(self, user_id):
         utc_dt = datetime.now(timezone.utc)  # UTC time
         dt = utc_dt.astimezone()

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -139,6 +139,16 @@ class Event(models.Model):
 
         data_dict['total_items'] = len(data_dict['items'])
         return data_dict
+    def delete_spectator(self, user):
+
+        try:
+            request_object = EventSpectators.objects.get(event=self, user=user)
+            request_object.delete()
+            return True
+        except EventSpectators.DoesNotExist:
+            return 401
+        except Exception as e:
+            return 500
     def add_spectator(self, user_id):
         utc_dt = datetime.now(timezone.utc)  # UTC time
         dt = utc_dt.astimezone()

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -78,6 +78,23 @@ class Event(models.Model):
         except Exception as e:
             return 500
 
+    def add_spectator(self, user_id):
+        utc_dt = datetime.now(timezone.utc)  # UTC time
+        dt = utc_dt.astimezone()
+
+        try:
+            num_of_spectators = len(self.interested_users.all())
+            if num_of_spectators >= self.maxSpectatorCapacity:
+                return 403 # Full Capacity
+            requester = User.objects.get(user_id=user_id)
+            EventSpectators.objects.create(event=self, user=requester, requested_on=dt)
+            return True
+        except User.DoesNotExist:  # User does not exist
+            return 401
+        except IntegrityError as e:  # already a spectator
+            return 402
+        except Exception as e:
+            return 500
 
 
 class EventParticipants(models.Model):

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -124,6 +124,13 @@ class Event(models.Model):
             data_dict['@id'] = interested.user.user_id
             data_dict['identifier'] = interested.user.identifier
 
+            if interested.message:
+                data_dict['additionalProperty'] = {
+                    "@type": "PropertyValue",
+                    "name": f"MessageToParticipateEvent{interested.event.event_id}",
+                    "value": interested.message
+                }
+
             interested_users.append(data_dict)
 
         return interested_users
@@ -393,5 +400,5 @@ class EventParticipationRequesters(models.Model):
 
     user = models.ForeignKey('User', related_name='interested_events', on_delete=models.CASCADE)
     event = models.ForeignKey('Event', related_name='interested_users', on_delete=models.CASCADE)
-    message = models.TextField()
+    message = models.TextField(blank=True)
     requested_on = models.DateTimeField()

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -33,6 +33,7 @@ class Event(models.Model):
     maxSkillLevel = models.IntegerField()
 
     acceptWithoutApproval = models.BooleanField()
+    duration = models.IntegerField()
 
     created_on = models.DateTimeField()
 

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -149,8 +149,7 @@ class Event(models.Model):
             with transaction.atomic():
                 for user in accept_user_id_list:
                     if num_remaining_places <= 0:
-                        data_dict['total_items'] = len(data_dict['items'])
-                        return data_dict
+                        break
 
                     try:
                         request_object = EventParticipationRequesters.objects.get(event=self, user=user)

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -82,6 +82,29 @@ class Event(models.Model):
     def add_participant(self, user_id_list):
         
         num_remaining_places = self.maximumAttendeeCapacity - len(self.participant_users.all())
+    def get_interesteds(self):
+
+        if self.acceptWithoutApproval:
+            return 400
+
+        try:
+            interesteds = self.interested_users.all()
+        except:
+            return 500
+
+        interested_users = []
+
+        for interested in interesteds:
+
+            data_dict = dict()
+
+            data_dict['@context'] = "https://schema.org/Person"
+            data_dict['@id'] = interested.user.user_id
+            data_dict['identifier'] = interested.user.identifier
+
+            interested_users.append(data_dict)
+
+        return interested_users
 
         data_dict = dict()
         data_dict['@context'] = "https://www.w3.org/ns/activitystreams"

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -3,7 +3,7 @@ import datetime
 from requests.api import get
 from ..helpers import get_address
 from django.db import IntegrityError, transaction
-from ..models import Sport
+from ..models import Sport, User
 from datetime import datetime, timezone
 
 class Event(models.Model):
@@ -62,6 +62,22 @@ class Event(models.Model):
             return 500
 
 
+    def add_interest(self, user_id):
+        
+        utc_dt = datetime.now(timezone.utc)  # UTC time
+        dt = utc_dt.astimezone()
+
+        try:
+            requester = User.objects.get(user_id=user_id)
+            EventParticipationRequesters.objects.create(event=self, user=requester, requested_on = dt)
+            return True
+        except User.DoesNotExist: # User does not exist
+            return 401
+        except IntegrityError as e: # already sent request
+            return 402 
+        except Exception as e:
+            return 500
+
 
 
 class EventParticipants(models.Model):
@@ -71,6 +87,7 @@ class EventParticipants(models.Model):
 
     user = models.ForeignKey('User', on_delete=models.CASCADE)
     event = models.ForeignKey('Event', on_delete=models.CASCADE)
+    accepted_on = models.DateTimeField()
 
 
 class EventSpectators(models.Model):
@@ -80,6 +97,7 @@ class EventSpectators(models.Model):
 
     user = models.ForeignKey('User', on_delete=models.CASCADE)
     event = models.ForeignKey('Event', on_delete=models.CASCADE)
+    joined_on = models.DateTimeField()
 
 
 class EventParticipationRequesters(models.Model):
@@ -89,3 +107,4 @@ class EventParticipationRequesters(models.Model):
 
     user = models.ForeignKey('User', on_delete=models.CASCADE)
     event = models.ForeignKey('Event', on_delete=models.CASCADE)
+    requested_on = models.DateTimeField()

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -243,6 +243,28 @@ class Event(models.Model):
 
         data_dict['total_items'] = len(data_dict['items'])
         return data_dict
+
+    def get_participants(self):
+
+        try:
+            participating = self.participant_users.all()
+        except Exception as e:
+            return 500
+
+        participant_users = []
+
+        for participant in participating:
+
+            data_dict = dict()
+
+            data_dict['@context'] = "https://schema.org/Person"
+            data_dict['@id'] = participant.user.user_id
+            data_dict['identifier'] = participant.user.identifier
+
+            participant_users.append(data_dict)
+
+        return participant_users
+
     def delete_interest(self, user):
 
         try:

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -30,6 +30,7 @@ class Event(models.Model):
     minSkillLevel = models.IntegerField()
     maxSkillLevel = models.IntegerField()
 
+    acceptWithoutApproval = models.BooleanField()
     created_on = models.DateTimeField()
 
     @staticmethod

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -185,4 +185,5 @@ class EventParticipationRequesters(models.Model):
 
     user = models.ForeignKey('User', related_name='interested_events', on_delete=models.CASCADE)
     event = models.ForeignKey('Event', related_name='interested_users', on_delete=models.CASCADE)
+    message = models.TextField()
     requested_on = models.DateTimeField()

--- a/back-end/sports_platform/sports_platform_api/tests/test_create_event.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_create_event.py
@@ -33,7 +33,8 @@ class CreateEventTest(TestCase):
                                     "maxSpectatorCapacity": 59,
                                     "minSkillLevel": 3,
                                     "maxSkillLevel": 5,
-                                    "acceptWithoutApproval": False
+                                    "acceptWithoutApproval": False,
+                                    "duration": 60
                                 }
 
 

--- a/back-end/sports_platform/sports_platform_api/tests/test_create_event.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_create_event.py
@@ -32,7 +32,8 @@ class CreateEventTest(TestCase):
                                     "maximumAttendeeCapacity": 50,
                                     "maxSpectatorCapacity": 59,
                                     "minSkillLevel": 3,
-                                    "maxSkillLevel": 5
+                                    "maxSkillLevel": 5,
+                                    "acceptWithoutApproval": False
                                 }
 
 

--- a/back-end/sports_platform/sports_platform_api/tests/test_participation.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_participation.py
@@ -1,0 +1,376 @@
+from django.test import Client, TestCase
+from ..models import Event, EventParticipationRequesters, EventSpectators, EventParticipants, Sport
+from rest_framework.authtoken.models import Token
+from django.contrib.auth import authenticate
+from .test_helper_functions import create_mock_user
+from datetime import datetime, timezone
+
+class ParticipationTest(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+        self.maxDiff = None
+
+        lion_info = {'identifier': 'lion',
+                     'password': 'roarroar', 'email': 'lion@roar.com'}
+        cat_info = {'identifier': 'cat',
+                    'password': 'meowmeow', 'email': 'cat@meow.com'}
+        dog_info = {'identifier': 'dog',
+                    'password': 'barkbark', 'email': 'dog@bark.com'}
+        sheep_info = {'identifier': 'sheep',
+                    'password': 'baabaa', 'email': 'sheep@baa.com'}
+
+        self.lion_user = create_mock_user(lion_info)
+        self.cat_user = create_mock_user(cat_info)
+        self.dog_user = create_mock_user(dog_info)
+        self.sheep_user = create_mock_user(sheep_info)
+
+
+        self.lion_token, _ = Token.objects.get_or_create(user=self.lion_user)
+        self.cat_token, _ = Token.objects.get_or_create(user=self.cat_user)
+        self.dog_token, _ = Token.objects.get_or_create(user=self.dog_user)
+        self.sheep_token, _ = Token.objects.get_or_create(user=self.sheep_user)
+
+
+        authenticate(identifier=self.lion_user.identifier,
+                     password=self.lion_user.password)
+        authenticate(identifier=self.cat_user.identifier,
+                     password=self.cat_user.password)
+        authenticate(identifier=self.dog_user.identifier,
+                     password=self.dog_user.password)
+        authenticate(identifier=self.sheep_user.identifier,
+                     password=self.sheep_user.password)
+
+        event_data_1 = {
+            "name": "Let's play soccer",
+            "sport": "soccer",
+            "startDate": "2021-12-13T13:00:00",
+            "latitude": 41.002697,
+            "longitude": 39.716763,
+            "minimumAttendeeCapacity": 1,
+            "maximumAttendeeCapacity": 2,
+            "maxSpectatorCapacity": 2,
+            "minSkillLevel": 1,
+            "maxSkillLevel": 3,
+            "acceptWithoutApproval": False,
+            "organizer": self.lion_user
+        }
+
+        event_data_2 = {
+            "name": "Basketball Time",
+            "sport": "basketball",
+            "startDate": "2021-09-18T15:00:00",
+            "latitude": 56.002697,
+            "longitude": 34.716763,
+            "minimumAttendeeCapacity": 1,
+            "maximumAttendeeCapacity": 1,
+            "maxSpectatorCapacity": 2,
+            "minSkillLevel": 1,
+            "maxSkillLevel": 2,
+            "acceptWithoutApproval": True,
+            "organizer": self.cat_user
+        }
+
+        event_data_3 = {
+            "name": "Soccer Time 2",
+            "sport": "soccer",
+            "startDate": "2021-12-13T13:00:00",
+            "latitude": 55.002697,
+            "longitude": 55.716763,
+            "minimumAttendeeCapacity": 1,
+            "maximumAttendeeCapacity": 2,
+            "maxSpectatorCapacity": 1,
+            "minSkillLevel": 1,
+            "maxSkillLevel": 3,
+            "acceptWithoutApproval": False,
+            "organizer": self.lion_user
+        }
+
+        Sport.objects.create(name="soccer")
+        Sport.objects.create(name="basketball")
+
+        self.event_with_approval = Event.objects.get(event_id = Event.create_event(event_data_1)['@id'])
+
+        self.event_without_approval = Event.objects.get(event_id=Event.create_event(event_data_2)['@id'])
+        self.event_3 = Event.objects.get(event_id=Event.create_event(event_data_3)['@id'])
+
+        utc_dt = datetime.now(timezone.utc)  # UTC time
+        dt = utc_dt.astimezone()
+
+        EventParticipants.objects.create(event = self.event_with_approval, user = self.dog_user, accepted_on = dt)
+        EventSpectators.objects.create(event = self.event_3, user=self.dog_user, requested_on = dt)
+        EventSpectators.objects.create(event=self.event_without_approval, user=self.dog_user, requested_on=dt)
+        EventParticipationRequesters.objects.create(event = self.event_with_approval, user = self.dog_user, requested_on = dt)
+        EventParticipationRequesters.objects.create(event = self.event_with_approval, user = self.cat_user, requested_on = dt)
+        EventParticipationRequesters.objects.create(event = self.event_with_approval, user = self.sheep_user, requested_on = dt)
+        
+
+        self.request_param = {'already_participating': self.event_with_approval.event_id,
+                              'already_spectator': self.event_without_approval.event_id,
+                              'full_spectator': self.event_3.event_id,
+                              'spectator_for_participating': self.event_with_approval.event_id,
+                              'wrong_event_id': self.event_with_approval.event_id + self.event_without_approval.event_id + self.event_3.event_id,
+
+                              'send_interest_success': self.event_with_approval.event_id,
+                              'send_spectator_success': self.event_without_approval.event_id,
+                              'participate_success': self.event_without_approval.event_id,
+
+                              'delete_interest': self.event_with_approval.event_id,
+                              'delete_spectator': self.event_3.event_id,
+                              'delete_participating': self.event_with_approval.event_id,
+                              'accept_reject_participants': self.event_with_approval.event_id,
+                              }
+
+        self.request_token = {'already_participating': self.dog_token,
+                              'already_spectator': self.dog_token,
+                              'full_spectator': self.cat_token,
+                              'spectator_for_participating': self.dog_token,
+                              'wrong_event_id': self.cat_token,
+                              'send_interest_success': self.lion_token,
+                              'send_spectator_success': self.cat_token,
+                              'participate_success': self.cat_token,
+                              'delete_interest': self.cat_token,
+                              'delete_spectator': self.dog_token,
+                              'delete_participating': self.dog_token,
+                              'accept_reject_participants': self.lion_token,
+                              }
+
+        self.response_bodies = {'already_participating': {"message": "Already participating the event."},
+                                'already_spectator': {"message": "Already a spectator for the event."},
+                                'full_spectator': {"message": "Spectator capacity is full for this event."},
+                                'spectator_for_participating': {"message": "Registered as participant to this event, if being spectator is wanted, remove participating status."},
+                                'wrong_event_id': {"message": "Try with a valid event."},
+                                'accept_reject_participants': {
+                                    "@context": "https://www.w3.org/ns/activitystreams",
+                                    "summary": f"{self.lion_user.identifier} accepted and rejected users to '{self.event_with_approval.name}' event",
+                                    "type": "Collection",
+                                    "items": [
+                                        {
+                                            "@context": "https://www.w3.org/ns/activitystreams",
+                                            "summary": f"{self.lion_user.identifier} accepted {self.cat_user.identifier} to event '{self.event_with_approval.name}'.",
+                                            "type": "Accept",
+                                            "actor": {
+                                                "type": "https://schema.org/Person",
+                                                "@id": self.lion_user.user_id,
+                                                "identifier": self.lion_user.identifier
+                                            },
+                                            "object": {
+                                                "type": "RequestToParticipate",
+                                                "actor": {
+                                                    "type": "https://schema.org/Person",
+                                                    "@id": self.cat_user.user_id,
+                                                    "identifier": self.cat_user.identifier
+                                                },
+                                                "object": {
+                                                    "type": "https://schema.org/SportsEvent",
+                                                    "@id": self.event_with_approval.event_id
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "@context": "https://www.w3.org/ns/activitystreams",
+                                            "summary": f"{self.lion_user.identifier} rejected {self.sheep_user.identifier}'s request to join the event '{self.event_with_approval.name}'.",
+                                            "type": "Reject",
+                                            "actor": {
+                                                "type": "https://schema.org/Person",
+                                                "@id": self.lion_user.user_id,
+                                                "identifier": self.lion_user.identifier
+                                            },
+                                            "object": {
+                                                "type": "RequestToParticipate",
+                                                "actor": {
+                                                    "type": "https://schema.org/Person",
+                                                    "@id": self.sheep_user.user_id,
+                                                    "identifier": self.sheep_user.identifier,
+                                                },
+                                                "object": {
+                                                    "type": "https://schema.org/SportsEvent",
+                                                    "@id": self.event_with_approval.event_id
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "total_items": 2
+                                }
+                            }
+
+        
+
+    def test_already_participating(self):
+        test_type = 'already_participating'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/interesteds"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_already_spectator(self):
+        test_type = 'already_spectator'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/spectators"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_full_spectator(self):
+        test_type = 'full_spectator'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/spectators"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_spectator_for_participating(self):
+        test_type = 'spectator_for_participating'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/spectators"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_wrong_event_id(self):
+        test_type = 'wrong_event_id'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/spectators"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+
+    def test_send_interest_success(self):
+        test_type = 'send_interest_success'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/interesteds"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(EventParticipationRequesters.objects.filter(
+            event=request_param, user=self.cat_user.user_id).exists())
+
+    def test_send_spectator_success(self):
+        test_type = 'send_spectator_success'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/spectators"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(EventSpectators.objects.filter(
+            event=request_param, user=self.cat_user.user_id).exists())
+
+    def test_participate_success(self):
+        test_type = 'participate_success'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/interesteds"
+
+        response = self.client.post(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(EventParticipants.objects.filter(
+            event=request_param, user=self.cat_user.user_id).exists())
+
+    def test_delete_interest(self):
+        test_type = 'delete_interest'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/interesteds"
+
+        response = self.client.delete(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(EventParticipationRequesters.objects.filter(
+            event=request_param, user=self.cat_user.user_id).exists())
+    
+    def test_delete_spectator(self):
+        test_type = 'delete_spectator'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/spectators"
+
+        response = self.client.delete(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(EventSpectators.objects.filter(
+            event=request_param, user=self.dog_user.user_id).exists())
+
+    def test_delete_participating(self):
+        test_type = 'delete_participating'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/participants"
+
+        response = self.client.delete(
+            path, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(EventParticipants.objects.filter(
+            event=request_param, user=self.dog_user.user_id).exists())
+
+    def test_accept_reject_participants(self):
+        test_type = 'accept_reject_participants'
+        request_param = self.request_param[test_type]
+        token = self.request_token[test_type]
+
+        path = "/events/" + str(request_param) + "/participants"
+
+        request_body = {
+            "accept_user_id_list": [self.sheep_user.user_id + 1, self.cat_user.user_id],
+            "reject_user_id_list": [45, self.sheep_user.user_id, 90, 132]
+        }
+
+        response = self.client.post(
+            path, request_body, content_type='application/json', **{'HTTP_AUTHORIZATION': f'Token {token}'})
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data, self.response_bodies[test_type])
+        self.assertTrue(EventParticipants.objects.filter(
+            event=request_param, user=self.cat_user.user_id).exists())
+        self.assertFalse(EventParticipationRequesters.objects.filter(
+            event=request_param, user=self.cat_user.user_id).exists())
+        self.assertFalse(EventParticipationRequesters.objects.filter(
+            event=request_param, user=self.sheep_user.user_id).exists())
+        self.assertFalse(EventParticipants.objects.filter(
+            event=request_param, user=self.sheep_user.user_id).exists())
+
+    
+
+    

--- a/back-end/sports_platform/sports_platform_api/tests/test_participation.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_participation.py
@@ -103,7 +103,7 @@ class ParticipationTest(TestCase):
         EventParticipants.objects.create(event = self.event_with_approval, user = self.dog_user, accepted_on = dt)
         EventSpectators.objects.create(event = self.event_3, user=self.dog_user, requested_on = dt)
         EventSpectators.objects.create(event=self.event_without_approval, user=self.dog_user, requested_on=dt)
-        EventParticipationRequesters.objects.create(event = self.event_with_approval, user = self.dog_user, requested_on = dt)
+        EventParticipationRequesters.objects.create(event = self.event_with_approval, user = self.dog_user, requested_on = dt, message = "Please accept, I really like this sport.")
         EventParticipationRequesters.objects.create(event = self.event_with_approval, user = self.cat_user, requested_on = dt)
         EventParticipationRequesters.objects.create(event = self.event_with_approval, user = self.sheep_user, requested_on = dt)
         

--- a/back-end/sports_platform/sports_platform_api/tests/test_participation.py
+++ b/back-end/sports_platform/sports_platform_api/tests/test_participation.py
@@ -53,7 +53,8 @@ class ParticipationTest(TestCase):
             "minSkillLevel": 1,
             "maxSkillLevel": 3,
             "acceptWithoutApproval": False,
-            "organizer": self.lion_user
+            "organizer": self.lion_user,
+            "duration": 20
         }
 
         event_data_2 = {
@@ -68,7 +69,8 @@ class ParticipationTest(TestCase):
             "minSkillLevel": 1,
             "maxSkillLevel": 2,
             "acceptWithoutApproval": True,
-            "organizer": self.cat_user
+            "organizer": self.cat_user,
+            "duration": 34
         }
 
         event_data_3 = {
@@ -83,7 +85,8 @@ class ParticipationTest(TestCase):
             "minSkillLevel": 1,
             "maxSkillLevel": 3,
             "acceptWithoutApproval": False,
-            "organizer": self.lion_user
+            "organizer": self.lion_user,
+            "duration": 45
         }
 
         Sport.objects.create(name="soccer")

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path('events', event_views.create_event),
     path('events/<int:event_id>/spectators', event_views.attend_spectator),
     path('events/<int:event_id>/interesteds', event_views.add_interest),
+    path('events/<int:event_id>/participants', event_views.accept_participant),
 ]

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path('users/<user_id>/visible_attributes', user_views.set_visibility),
 
     path('events', event_views.create_event),
+    path('events/<int:event_id>/spectators', event_views.attend_spectator),
 ]

--- a/back-end/sports_platform/sports_platform_api/urls.py
+++ b/back-end/sports_platform/sports_platform_api/urls.py
@@ -16,4 +16,5 @@ urlpatterns = [
 
     path('events', event_views.create_event),
     path('events/<int:event_id>/spectators', event_views.attend_spectator),
+    path('events/<int:event_id>/interesteds', event_views.add_interest),
 ]

--- a/back-end/sports_platform/sports_platform_api/validation/event_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/event_validation.py
@@ -16,6 +16,7 @@ class Event(serializers.Serializer):
     maxSpectatorCapacity = serializers.IntegerField(min_value=0, required=True)
     minSkillLevel = serializers.IntegerField(min_value=1, max_value=5, required=True)
     maxSkillLevel = serializers.IntegerField(min_value=1, max_value=5, required=True)
+    acceptWithoutApproval = serializers.BooleanField(required=True)
 
     def validate(self, data):
 

--- a/back-end/sports_platform/sports_platform_api/validation/event_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/event_validation.py
@@ -17,6 +17,7 @@ class Event(serializers.Serializer):
     minSkillLevel = serializers.IntegerField(min_value=1, max_value=5, required=True)
     maxSkillLevel = serializers.IntegerField(min_value=1, max_value=5, required=True)
     acceptWithoutApproval = serializers.BooleanField(required=True)
+    duration = serializers.IntegerField(min_value=1, max_value=9223372036854775807)
 
     def validate(self, data):
 

--- a/back-end/sports_platform/sports_platform_api/validation/event_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/event_validation.py
@@ -26,3 +26,10 @@ class Event(serializers.Serializer):
             raise serializers.ValidationError({"time": "startDate should include time"})
 
         return data
+
+
+class Accept_Participant(serializers.Serializer):
+    user_id_list = serializers.ListField(
+        child=serializers.IntegerField(
+            min_value=0, max_value=9223372036854775807)
+    )

--- a/back-end/sports_platform/sports_platform_api/validation/event_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/event_validation.py
@@ -28,6 +28,8 @@ class Event(serializers.Serializer):
 
         return data
 
+class Request_Message(serializers.Serializer):
+    message = serializers.CharField(required=False)
 
 class Accept_Participant(serializers.Serializer):
     user_id_list = serializers.ListField(

--- a/back-end/sports_platform/sports_platform_api/validation/event_validation.py
+++ b/back-end/sports_platform/sports_platform_api/validation/event_validation.py
@@ -32,7 +32,11 @@ class Request_Message(serializers.Serializer):
     message = serializers.CharField(required=False)
 
 class Accept_Participant(serializers.Serializer):
-    user_id_list = serializers.ListField(
+    accept_user_id_list = serializers.ListField(
+        child=serializers.IntegerField(
+            min_value=0, max_value=9223372036854775807)
+    )
+    reject_user_id_list = serializers.ListField(
         child=serializers.IntegerField(
             min_value=0, max_value=9223372036854775807)
     )

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -94,6 +94,32 @@ def attend_spectator(request, event_id):
                 return Response(data=event_dict, status=200)
         except Exception as e:
             return Response(data={"message": 'Try later.'}, status=500)
+
+    elif request.method == 'DELETE':
+
+        if not request.user.is_authenticated:
+            return Response({"message": "User not logged in."},
+                            status=401)
+
+        user = request.user
+
+        try:
+            event = Event.objects.get(event_id=event_id)
+
+            res = event.delete_spectator(user)
+
+            if res == 401:
+                return Response(data={"message": "Not a spectator for this event"}, status=400)
+            if res == 500:
+                return Response(data={"message": 'Try later.'}, status=500)
+            else:
+                return Response(status=204)
+        except Event.DoesNotExist:
+            return Response(data={"message": "Try with a valid event."}, status=400)
+        except Exception as e:
+            return Response(data={"message": 'Try later.'}, status=500)
+
+
 def add_interest(request, event_id):
 
     if not request.user.is_authenticated:

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -245,3 +245,23 @@ def accept_participant(request, event_id):
             print(e)
             return Response(data={"message": 'Try later.'}, status=500)
         
+    elif request.method == 'GET':
+
+        try:
+            event = Event.objects.get(event_id=event_id)
+
+            res = event.get_participants()
+            event_dict = dict()
+            event_dict['@context'] = "https://schema.org/SportsEvent"
+            event_dict['@id'] = event.event_id
+
+            if res == 500:
+                return Response(data={"message": "Try later."}, status=500)
+            else:
+                event_dict['attendee'] = res
+                return Response(data=event_dict, status=200)
+        except Event.DoesNotExist:
+            return Response(data={"message": "Try with a valid event."}, status=400)
+        except Exception as e:
+            return Response(data={"message": 'Try later.'}, status=500)
+

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -184,6 +184,32 @@ def add_interest(request, event_id):
         except Event.DoesNotExist:
             return Response(data={"message": "Try with a valid event."}, status=400)
         except Exception as e:
+            print("hey")
+            print(e)
+            return Response(data={"message": 'Try later.'}, status=500)
+
+    elif request.method == 'DELETE':
+
+        if not request.user.is_authenticated:
+            return Response({"message": "User not logged in."},
+                            status=401)
+
+        user = request.user
+
+        try:
+            event = Event.objects.get(event_id=event_id)
+
+            res = event.delete_interest(user)
+
+            if res == 401:
+                return Response(data={"message": "Not interested for this event"}, status=400)
+            if res == 500:
+                return Response(data={"message": 'Try later.'}, status=500)
+            else:
+                return Response(status=204)
+        except Event.DoesNotExist:
+            return Response(data={"message": "Try with a valid event."}, status=400)
+        except Exception as e:
             return Response(data={"message": 'Try later.'}, status=500)
 def accept_participant(request, event_id):
 

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -43,38 +43,41 @@ def create_event(request):
         return Response(data={"message": 'There is an internal error, try again later.'}, status=500)
 
 
-@api_view(['POST'])
+@api_view(['POST', 'GET', 'DELETE'])
 def attend_spectator(request, event_id):
 
-    if not request.user.is_authenticated:
-        return Response({"message": "User not logged in."},
-                        status=401)
+    if request.method == 'POST':
+        if not request.user.is_authenticated:
+            return Response({"message": "User not logged in."},
+                            status=401)
 
-    user = request.user
+        user = request.user
 
-    try:
-        event = Event.objects.get(event_id = event_id)            
+        try:
+            event = Event.objects.get(event_id = event_id)            
 
-        res = event.add_spectator(user.user_id)
+            res = event.add_spectator(user.user_id)
 
-        if res == 401:
-            return Response(data={"message": "Try with a valid user."}, status=400)
-        elif res == 402:
-            return Response(data={"message": "Already a spectator for the event."}, status=400)
-        elif res == 403:
-            return Response(data={"message": "Spectator capacity is full for this event."}, status=400)
-        elif res == 500:
-            return Response(data={"message": "Try later."}, status=500)
-        else:
-            return Response(status=201)
+            if res == 401:
+                return Response(data={"message": "Try with a valid user."}, status=400)
+            elif res == 402:
+                return Response(data={"message": "Already a spectator for the event."}, status=400)
+            elif res == 403:
+                return Response(data={"message": "Spectator capacity is full for this event."}, status=400)
+            elif res == 404:
+                return Response(data={"message": "Registered as participant to this event, if being spectator is wanted, remove participating status."}, status=400)
+            elif res == 404:
+                return Response(data={"message": "Showed interest to participate this event. If spectator status is wanted remove the interest."}, status=400)
+            elif res == 500:
+                return Response(data={"message": "Try later."}, status=500)
+            else:
+                return Response(status=201)
 
-    except Event.DoesNotExist:
-        return Response(data={"message": "Try with a valid event."}, status=400)
-    except Exception:
-        return Response(data={"message": 'Try later.'}, status=500)
+        except Event.DoesNotExist:
+            return Response(data={"message": "Try with a valid event."}, status=400)
+        except Exception:
+            return Response(data={"message": 'Try later.'}, status=500)
 
-
-@api_view(['POST'])
 def add_interest(request, event_id):
 
     if not request.user.is_authenticated:

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -70,3 +70,30 @@ def attend_spectator(request, event_id):
 
     except Exception:
         return Response(data={"message": 'Try later.'}, status=500)
+
+
+@api_view(['POST'])
+def add_interest(request, event_id):
+
+    if not request.user.is_authenticated:
+        return Response({"message": "User not logged in."},
+                        status=401)
+
+    user = request.user
+
+    try:
+        event = Event.objects.get(event_id=event_id)
+
+        res = event.add_interest(user.user_id)
+
+        if res == 401:
+            return Response(data={"message": "Try with a valid user."}, status=400)
+        elif res == 402:
+            return Response(data={"message": "Already sent request for the event."}, status=400)
+        elif res == 500:
+            return Response(data={"message": "Try later."}, status=500)
+        else:
+            return Response(status=201)
+
+    except Exception:
+        return Response(data={"message": 'Try later.'}, status=500)

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -265,3 +265,26 @@ def accept_participant(request, event_id):
         except Exception as e:
             return Response(data={"message": 'Try later.'}, status=500)
 
+    elif request.method == 'DELETE':
+
+        if not request.user.is_authenticated:
+            return Response({"message": "User not logged in."},
+                            status=401)
+
+        user = request.user
+
+        try:
+            event = Event.objects.get(event_id=event_id)
+
+            res = event.delete_participant(user)
+
+            if res == 401:
+                return Response(data={"message": "Not participanting for this event"}, status=400)
+            if res == 500:
+                return Response(data={"message": 'Try later.'}, status=500)
+            else:
+                return Response(status=204)
+        except Event.DoesNotExist:
+            return Response(data={"message": "Try with a valid event."}, status=400)
+        except Exception as e:
+            return Response(data={"message": 'Try later.'}, status=500)

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -78,6 +78,22 @@ def attend_spectator(request, event_id):
         except Exception:
             return Response(data={"message": 'Try later.'}, status=500)
 
+    elif request.method == 'GET':
+        try:
+            event = Event.objects.get(event_id=event_id)
+
+            res = event.get_participants()
+            event_dict = dict()
+            event_dict['@context'] = "https://schema.org/SportsEvent"
+            event_dict['@id'] = event.event_id
+
+            if res == 500:
+                return Response(data={"message": "Try later."}, status=500)
+            else:
+                event_dict['audience'] = res
+                return Response(data=event_dict, status=200)
+        except Exception as e:
+            return Response(data={"message": 'Try later.'}, status=500)
 def add_interest(request, event_id):
 
     if not request.user.is_authenticated:

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -1,3 +1,4 @@
+import requests
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from ..models import Event
@@ -92,6 +93,9 @@ def attend_spectator(request, event_id):
             else:
                 event_dict['audience'] = res
                 return Response(data=event_dict, status=200)
+
+        except Event.DoesNotExist:
+            return Response(data={"message": "Try with a valid event."}, status=400)
         except Exception as e:
             return Response(data={"message": 'Try later.'}, status=500)
 
@@ -156,8 +160,6 @@ def add_interest(request, event_id):
         except Event.DoesNotExist:
             return Response(data={"message": "Try with a valid event."}, status=400)
         except Exception as e:
-            print("hey")
-            print(e)
             return Response(data={"message": 'Try later.'}, status=500)
 
     elif request.method == 'GET':
@@ -174,6 +176,8 @@ def add_interest(request, event_id):
 
             if res == 500:
                 return Response(data={"message": "Try later."}, status=500)
+            elif res == 400:
+                return Response(data={"message": "This event does not require organizer approval to participate."}, status=400)
             else:
                 event_dict['additionalProperty'] = {
                     "@type": "PropertyValue",
@@ -184,8 +188,6 @@ def add_interest(request, event_id):
         except Event.DoesNotExist:
             return Response(data={"message": "Try with a valid event."}, status=400)
         except Exception as e:
-            print("hey")
-            print(e)
             return Response(data={"message": 'Try later.'}, status=500)
 
     elif request.method == 'DELETE':
@@ -243,11 +245,10 @@ def accept_participant(request, event_id):
             if res == 401:
                 return Response(data={"message": "This event accepts participants without approval."}, status=500)
             else:
-                return Response(data = res, status=200)
+                return Response(data = res, status=201)
         except Event.DoesNotExist:
             return Response(data={"message": "Try with a valid event."}, status=400)
         except Exception as e:
-            print(e)
             return Response(data={"message": 'Try later.'}, status=500)
         
     elif request.method == 'GET':

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -211,6 +211,11 @@ def add_interest(request, event_id):
             return Response(data={"message": "Try with a valid event."}, status=400)
         except Exception as e:
             return Response(data={"message": 'Try later.'}, status=500)
+
+        
+
+
+@api_view(['POST', 'GET', 'DELETE'])
 def accept_participant(request, event_id):
 
     if request.method == 'POST':

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -159,6 +159,32 @@ def add_interest(request, event_id):
             print("hey")
             print(e)
             return Response(data={"message": 'Try later.'}, status=500)
+
+    elif request.method == 'GET':
+
+        try:
+            event = Event.objects.get(event_id=event_id)
+
+            res = event.get_interesteds()
+
+            event_dict = dict()
+            event_dict['@context'] = "https://schema.org/SportsEvent"
+            event_dict['@id'] = event.event_id
+
+
+            if res == 500:
+                return Response(data={"message": "Try later."}, status=500)
+            else:
+                event_dict['additionalProperty'] = {
+                    "@type": "PropertyValue",
+                    "name": "interesteds",
+                    "value": res
+                }
+                return Response(data=event_dict, status=200)
+        except Event.DoesNotExist:
+            return Response(data={"message": "Try with a valid event."}, status=400)
+        except Exception as e:
+            return Response(data={"message": 'Try later.'}, status=500)
 def accept_participant(request, event_id):
 
     if not request.user.is_authenticated:

--- a/back-end/sports_platform/sports_platform_api/views/event_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/event_views.py
@@ -41,3 +41,32 @@ def create_event(request):
         
     except Exception:
         return Response(data={"message": 'There is an internal error, try again later.'}, status=500)
+
+
+@api_view(['POST'])
+def attend_spectator(request, event_id):
+
+    if not request.user.is_authenticated:
+        return Response({"message": "User not logged in."},
+                        status=401)
+
+    user = request.user
+
+    try:
+        event = Event.objects.get(event_id = event_id)
+
+        res = event.add_spectator(user.user_id)
+
+        if res == 401:
+            return Response(data={"message": "Try with a valid user."}, status=400)
+        elif res == 402:
+            return Response(data={"message": "Already a spectator for the event."}, status=400)
+        elif res == 403:
+            return Response(data={"message": "Spectator capacity is full for this event."}, status=400)
+        elif res == 500:
+            return Response(data={"message": "Try later."}, status=500)
+        else:
+            return Response(status=201)
+
+    except Exception:
+        return Response(data={"message": 'Try later.'}, status=500)

--- a/back-end/sports_platform/sports_platform_api/views/user_views.py
+++ b/back-end/sports_platform/sports_platform_api/views/user_views.py
@@ -169,7 +169,7 @@ def follow_user(request, user_id):
                 return Response(status=200)
 
         except Exception as e:
-            return Response(data=str(e), status=500)
+            return Response(data={"message": "Try later."}, status=500)
 
     elif request.method == 'DELETE':
         current_user = request.user


### PR DESCRIPTION
Endpoints related to event participation are implemented.
These include:
- sending request to participate an event
- attending as spectator
- accepting and rejecting interested users
- deleting any participating status(interested, spectator, participating)
- getting event interesteds, participants, spectators

Activity stream response is returned on accepting and rejecting participants.
Get requests return the SportsEvent schema with related properties.