### PR TITLE
Fix Reverse Geocoding

### DIFF
--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -80,9 +80,32 @@ class Event(models.Model):
         elif address == 400:
             return 101
 
+        order = ["state", "province", 
+                 "district", "county", "municipality", "city", "town", "village", "hamlet"]
+
         data['country'] = address['country']
-        data['city'] = address['state']
-        data['district'] = address['county']
+
+        i = 0
+        c = 0
+
+        while i<len(order):
+            if order[i] not in address.keys():
+                i+=1
+                print(i)
+                continue
+            if c==0:
+                data['city'] = address[order[i]]
+                i+=1
+                c+=1
+            else:
+                data['district'] = address[order[i]]
+                c+=1
+                break
+        
+        if c<1:
+            data['city'] = ""
+        if c<2:
+            data['district'] = ""
 
         try:
             data['sport'] = Sport.objects.get(name=data['sport'])

--- a/back-end/sports_platform/sports_platform_api/models/event_models.py
+++ b/back-end/sports_platform/sports_platform_api/models/event_models.py
@@ -91,7 +91,6 @@ class Event(models.Model):
         while i<len(order):
             if order[i] not in address.keys():
                 i+=1
-                print(i)
                 continue
             if c==0:
                 data['city'] = address[order[i]]


### PR DESCRIPTION
As stated on issue #302 , reverse geocoding was returning different keys for some different addresses. On one address, "Istanbul" was given with "province" key and "Trabzon" was given with "state" key. To fix this, admin levels of the addresses are used. "city" is taken as the biggest level after country without region. "district" is taken as the next present level.
Order of the keys can be found here since Nominatim follows OpenStreetMap rules:
https://wiki.openstreetmap.org/wiki/Key:place#Relationship_with_admin_level